### PR TITLE
set `ORA_SDTZ` before connecting to the database

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -3,10 +3,10 @@
 #'
 #' @export
 initialize_connection <- function() {
-  drv <- dbDriver("Oracle")
-  conn <- dbConnect(drv, dbname = "IPIAMPR2.WORLD")
   Sys.setenv(TZ = "Europe/Paris")
   Sys.setenv(ORA_SDTZ = "Europe/Paris")
+  drv <- dbDriver("Oracle")
+  conn <- dbConnect(drv, dbname = "IPIAMPR2.WORLD")
   return(conn)
 }
 


### PR DESCRIPTION
Salut,

[D'après mes tests](https://soeiro.gitlab.io/pepidoc/logiciels.html#dates-heures-et-fuseaux-horaires), il faut paramétrer la variable d’environnement `ORA_SDTZ` _avant_ de se connecter à la base de donnée, sinon c'est sans effet.

PS: typo dans le message de commit, il faudrait ajouter `ORA_SDTZ` (entre "set" et "before") avant de merger.